### PR TITLE
Remix: Remove Scripts and ScrollRestoration for static content

### DIFF
--- a/remix/app/root.jsx
+++ b/remix/app/root.jsx
@@ -30,10 +30,6 @@ export default function App() {
         <Header />
         <Outlet />
 
-        <ScrollRestoration />
-
-        <Scripts />
-
         <LiveReload />
         <Footer />
       </body>


### PR DESCRIPTION
Remix has the ability to include client-side hydration or not depending on the content. Since the example is entirely static (not even using Links for client-side navigations to posts from the index), having the `Scripts` and `ScrollRestoration` components is purely overhead.

Related documentation: https://remix.run/docs/en/v1/guides/disabling-javascript#disabling-javascript
Since none of the pages need hydration, I left out the `Scripts` and `handle` implementation entirely.